### PR TITLE
Versioned IRIs removed from import statements

### DIFF
--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -4,8 +4,6 @@
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/maintenance/Maintenance/" uri="./maintenance/Maintenance.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/Core/" uri="./core/Core.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/" uri="./core/meta/AnnotationVocabulary.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/20220506/Core/" uri="./core/Core.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/20221028/Core/" uri="./core/Core.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/202202/core/MappingCommonsToIOFCore/" uri="./core/commons-to-core-mapping/MappingCommonsToIOF.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/MappingCommonsToIOFCore/" uri="./core/commons-to-core-mapping/MappingCommonsToIOF.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/meta/MappingAnnotationVocabularyToCommons/" uri="./core/commons-to-core-mapping/meta/MappingAnnotationVocabularyToCommons.rdf"/>

--- a/maintenance/Maintenance.rdf
+++ b/maintenance/Maintenance.rdf
@@ -17,7 +17,7 @@
     xmlns:iof-maint="https://dev.industrialontologies.org/ontology/maintenance/MaintenanceReferenceOntology/">
     <owl:Ontology rdf:about="https://dev.industrialontologies.org/ontology/maintenance/MaintenanceReferenceOntology/">
         <owl:versionIRI rdf:resource="https://dev.industrialontologies.org/ontology/maintenance/20221108/MaintenanceReferenceOntology/" />
-        <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/20221028/Core/" />
+        <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/Core/" />
         <dcterms:abstract>The purpose of this IOF Maintenance Reference ontology is to support semantic interoperatibility through the use modular ontologies in the maintenance domain. This Ontology contains terms and concepts identified as common in a number of application ontologies for maintenance management, maintenance procedures, asset failure and failure modes and effects analysis. The ontology is aligned with the IOF Core Ontology which is aligned with Basic Formal Ontology and importas terms for other domain independent ontologies. </dcterms:abstract>
         <dcterms:contributor xml:lang="en">Caitlin Woods, University of Western Australia</dcterms:contributor>
         <dcterms:contributor xml:lang="en">Markus Stumptner, University of South Australia</dcterms:contributor>

--- a/productionplanning/mfg-planning.rdf
+++ b/productionplanning/mfg-planning.rdf
@@ -33,7 +33,7 @@
 	<owl:Ontology rdf:about="http://simpom.ohio.edu/mfg-planning/">
 		<rdfs:label xml:lang="en">Manufacturing Resource Capability</rdfs:label>
 		<dc:contributor xml:lang="en">Arkopaul Sarkar, Dusan Sormaz</dc:contributor>
-		<owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/20220506/Core/"/>
+		<owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/Core/"/>
 		<owl:versionInfo xml:lang="en">Version 1.0</owl:versionInfo>
 	</owl:Ontology>
 	


### PR DESCRIPTION
Signed-off-by: mereolog <pawel.garbacz@makolab.com>

This hot-fix removes the versioned IRIs from import statements because they do not resolve.
In the future we may use versioned IRIs in this capacity provided that  they are based on GitHub tags.