### PR TITLE
Hotfix to wrong IRIs in Metadata.rdf file

### DIFF
--- a/core/Metadatacore.rdf
+++ b/core/Metadatacore.rdf
@@ -25,7 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.industrialontologies.org/ontology/core/Metadatacore/">
 		<rdfs:label>IOF Core Ontologies Library</rdfs:label>
-		<dct:abstract>The IOF Core Meta Ontology specifies the metada for the IOF Core Ontology Library</dct:abstract>
+		<dct:abstract>The IOF Core Meta Ontology specifies the metadata for the IOF Core Ontology Library</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2023-01-20T00:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/Core/"/>

--- a/core/Metadatacore.rdf
+++ b/core/Metadatacore.rdf
@@ -30,8 +30,8 @@
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/Core/"/>
 		<owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/MappingCommonsToIOFCore/"/>
+		<owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/meta/MappingAnnotationVocabularyToCommons/"/>
 		<owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/meta/MappingAnnotationVocabularyToCommons/"/>
 		<owl:versionIRI rdf:resource="https://spec.industrialontologies.org/ontology/20230120/core/Metadatacore/"/>
 		<iof-av:copyright>Copyright (c) 2023 Open Applications Group</iof-av:copyright>
 	</owl:Ontology>
@@ -41,9 +41,9 @@
 		<rdfs:label>IOF Core Ontologies Library</rdfs:label>
 		<dct:abstract>The IOF Core Ontologies Library contains ontologies to be used across multiple manufacturing domains.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.industrialontologies.org/ontology/core/Core/"/>
-		<dct:hasPart rdf:resource="https://spec.industrialontologies.org/ontology/core/MappingCommonsToIOFCore/"/>
+		<dct:hasPart rdf:resource="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/MappingCommonsToIOF/"/>
+		<dct:hasPart rdf:resource="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/meta/MappingAnnotationVocabularyToCommons/"/>
 		<dct:hasPart rdf:resource="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/"/>
-		<dct:hasPart rdf:resource="https://spec.industrialontologies.org/ontology/core/meta/MappingAnnotationVocabularyToCommons/"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/core/commonstocoremapping/meta/MappingAnnotationVocabularyToCommons.rdf
+++ b/core/commonstocoremapping/meta/MappingAnnotationVocabularyToCommons.rdf
@@ -32,7 +32,7 @@
 		<dct:title xml:lang="en-US">Industrial Ontology Foundry (IOF) Mapping from the IOF Annotation Vocabulary to the Object Management Group (OMG) Commons Ontology Library Annotation Vocabulary</dct:title>
 		<owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/Commons/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.industrialontologies.org/ontology/20221020/core/meta/MappingAnnotationVocabularyToCommons/"/>
+		<owl:versionIRI rdf:resource="https://spec.industrialontologies.org/ontology/20221020/core/commonstocoremapping/meta/MappingAnnotationVocabularyToCommons/"/>
 		<iof-av:copyright>Copyright (c) 2022 EDM Council, Inc.</iof-av:copyright>
 		<iof-av:copyright>Copyright (c) 2022 Open Applications Group</iof-av:copyright>
 		<iof-av:maturity rdf:resource="&iof-av;Released"/>


### PR DESCRIPTION
Signed-off-by: mereolog <pawel.garbacz@makolab.com>

A couple of typos in ontologies' IRIs in metadata ontology files are fixed.