### PR TITLE
Language matching fixed in hygiene tests

### DIFF
--- a/etc/testing/hygiene_parameterized/testHygiene_definitions.sparql
+++ b/etc/testing/hygiene_parameterized/testHygiene_definitions.sparql
@@ -14,7 +14,7 @@ WHERE
 {
   ?resource rdf:type ?type.
   VALUES ?type {owl:Class owl:ObjectProperty owl:DatatypeProperty}
-  FILTER NOT EXISTS {?resource iof-av:naturalLanguageDefinition ?definition. FILTER (langMatches(LANG(?definition),"en-US"))}
+  FILTER NOT EXISTS {?resource iof-av:naturalLanguageDefinition ?definition. FILTER (LANG(?definition) = "en-US")}
   
   FILTER REGEX(STR(?resource), <HYGIENE_TESTS_FILTER_PARAMETER>)
 

--- a/etc/testing/hygiene_parameterized/testHygiene_labels.sparql
+++ b/etc/testing/hygiene_parameterized/testHygiene_labels.sparql
@@ -14,7 +14,7 @@ WHERE
   ?resource rdf:type ?type.
   VALUES ?type {owl:Class owl:ObjectProperty owl:DatatypeProperty}
   
-  FILTER NOT EXISTS {?resource rdfs:label ?label. FILTER (langMatches(LANG(?label),"en-US"))}
+  FILTER NOT EXISTS {?resource rdfs:label ?label. FILTER (LANG(?definition) = "en-US")}
   FILTER ISIRI(?resource)
   
   FILTER REGEX(STR(?resource), <HYGIENE_TESTS_FILTER_PARAMETER>)


### PR DESCRIPTION
This pull request allows to find improper language tags where only the letter case is wrong, e.g., 'en-us' instead of 'en-US'