### PR TITLE
Maint edit 23 3

### DIFF
--- a/maintenance/MaintenanceReferenceOntology.rdf
+++ b/maintenance/MaintenanceReferenceOntology.rdf
@@ -379,42 +379,26 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&iof-core;satisfiesRequirement"/>
-				<owl:someValuesFrom rdf:resource="&iof-maint;QualificationSpecification"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&iof-maint;QualificationSpecification">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&iof-core;prescribes"/>
+								<owl:someValuesFrom rdf:resource="&iof-maint;MaintenanceActivity"/>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>qualified maintenance person</rdfs:label>
 		<rdfs:seeAlso>qualification specification</rdfs:seeAlso>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:intersectionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&iof-core;Person">
-					</rdf:Description>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&obo;BFO_0000056"/>
-						<owl:someValuesFrom rdf:resource="&iof-maint;MaintenanceActivity"/>
-					</owl:Restriction>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&iof-core;satisfiesRequirement"/>
-						<owl:someValuesFrom>
-							<owl:Class>
-								<owl:intersectionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&iof-maint;QualificationSpecification">
-									</rdf:Description>
-									<owl:Restriction>
-										<owl:onProperty rdf:resource="&iof-core;prescribes"/>
-										<owl:someValuesFrom rdf:resource="&iof-maint;MaintenanceActivity"/>
-									</owl:Restriction>
-								</owl:intersectionOf>
-							</owl:Class>
-						</owl:someValuesFrom>
-					</owl:Restriction>
-				</owl:intersectionOf>
-			</owl:Class>
-		</owl:equivalentClass>
 		<skos:example>electrician, fitter, mechanic</skos:example>
 		<iof-av:explanatoryNote>Qualified person on its own is not particularly useful unless reasoning is constrained to only the individuals of interest at some time. Specific subtypes of qualified person are necessary to determine if specific qualification types  are satisfied. Still, care must be taken when reasoning over temporal information as, if the critieria are met at some time, the calssification will hold.</iof-av:explanatoryNote>
 		<iof-av:firstOrderLogicDefinition>QualifiedPerson(x) ↔ Person(x) ∧ ∃y(MaintenanceActivity(y) ∧ partcipatesInAtSomeTime(x,y) ∧ ∃z(QualificationSpecification(z) ∧ prescribedBy(y, z) ∧ satisfiesRequirement(x,z)))</iof-av:firstOrderLogicDefinition>
-		<iof-av:isPrimitive rdf:datatype="&xsd;boolean">false</iof-av:isPrimitive>
+		<iof-av:isPrimitive rdf:datatype="&xsd;boolean">true</iof-av:isPrimitive>
 		<iof-av:maturity>Provisional</iof-av:maturity>
 		<iof-av:naturalLanguageDefinition>person who is qualified to perform a specified process or task</iof-av:naturalLanguageDefinition>
 		<iof-av:semiFormalNaturalLanguageDefinition>&apos;qualified person&apos;: every  instance of &apos;qualified person&apos; is defined as exactly an instance of &apos;person&apos; that &apos;participates in at some time&apos; some &apos;maintenance activity&apos; p and that &apos;satifies&apos; some &apos;qualification specification&apos; that &apos;prescribes&apos; p</iof-av:semiFormalNaturalLanguageDefinition>

--- a/maintenance/MaintenanceReferenceOntology.rdf
+++ b/maintenance/MaintenanceReferenceOntology.rdf
@@ -12,7 +12,8 @@
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF
+<rdf:RDF xml:base="https://spec.industrialontologies.org/ontology/maintenance/MaintenanceReferenceOntology/"
+	xmlns="https://spec.industrialontologies.org/ontology/maintenance/MaintenanceReferenceOntology/"
 	xmlns:dc="http://purl.org/dc/elements/1.1/"
 	xmlns:dcterms="http://purl.org/dc/terms/"
 	xmlns:iof-av="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/"
@@ -457,7 +458,7 @@
 	
 	<owl:ObjectProperty rdf:about="&iof-maint;hasState">
 		<rdfs:subPropertyOf rdf:resource="&obo;BFO_0000056"/>
-		<rdfs:label>hasMaintainableMaterialState</rdfs:label>
+		<rdfs:label>has maintainable material state</rdfs:label>
 		<rdfs:domain rdf:resource="&iof-core;MaintainableMaterialItem"/>
 		<rdfs:range rdf:resource="&iof-maint;MaintenanceState"/>
 		<owl:inverseOf rdf:resource="&iof-maint;stateOf"/>

--- a/maintenance/MaintenanceReferenceOntology.rdf
+++ b/maintenance/MaintenanceReferenceOntology.rdf
@@ -130,7 +130,7 @@
 		<skos:example>is broken in two, is burst, is failing to turn on</skos:example>
 		<iof-av:firstOrderLogicDefinition>FailedState(o1) ↔ MaintenanceState(o1) ∧ ∃i(MaintainableMaterialItem(i) ∧  hasParticipantAtAllTimes(o1, i) ∧ ∃e(FailureEvent(e) ∧  initiates(e, o1)) ∧ ∃o2((DegradedState(o2) ∨ OperatingState(o2) ∧ hasParticipantAtAllTimes(o2,i)) ∧ precedes(o2, o1)) ∧ ¬∃o3((DegradedState(o3) ∨ OperatingState(o3)) ∧ hasParticipantAtAllTimes(o3,i) ∧ precedes(o2, o3) ∧ precedes(o3, o1)))</iof-av:firstOrderLogicDefinition>
 		<iof-av:isPrimitive rdf:datatype="&xsd;boolean">false</iof-av:isPrimitive>
-		<iof-av:maturity>Release</iof-av:maturity>
+		<iof-av:maturity>provisional</iof-av:maturity>
 		<iof-av:naturalLanguageDefinition>state of an item being unable to perform a required function due to a failure event</iof-av:naturalLanguageDefinition>
 		<iof-av:semiFormalNaturalLanguageDefinition>&quot;failed state&apos;: every instance of &apos;failed state&apos; is defined as exactly an instance of &apos;maintenance state&apos; o1 that &apos;has participant at all times&apos; some &apos;maintainable material item&apos; i and that is &apos;initiated by&apos; some &apos;failure event&apos; and is &apos;preceded by&apos; some (&apos;degraded state&apos; or &apos;operating state&apos;) o2 that &apos;has participant at all times&apos; i and there is no (&apos;degraded state&apos; or &apos;operating state&apos; ) o3 such that o3 &apos;has participant at all times&apos; i and o2 &apos;precedes&apos; o3 and o3 &apos;precedes&apos; o1&quot;</iof-av:semiFormalNaturalLanguageDefinition>
 	</owl:Class>
@@ -484,7 +484,7 @@
 	
 	<owl:ObjectProperty rdf:about="&iof-maint;stateOf">
 		<rdfs:subPropertyOf rdf:resource="&obo;BFO_0000167"/>
-		<rdfs:label>maintainableMaterialStateOf</rdfs:label>
+		<rdfs:label>maintainable material state of</rdfs:label>
 		<rdfs:domain rdf:resource="&iof-maint;MaintenanceState"/>
 		<rdfs:range rdf:resource="&iof-core;MaintainableMaterialItem"/>
 		<iof-av:maturity>Provisional</iof-av:maturity>

--- a/maintenance/MaintenanceReferenceOntology.rdf
+++ b/maintenance/MaintenanceReferenceOntology.rdf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
+	<!ENTITY dc "http://purl.org/dc/elements/1.1/">
 	<!ENTITY dcterms "http://purl.org/dc/terms/">
 	<!ENTITY iof-av "https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/">
 	<!ENTITY iof-core "https://spec.industrialontologies.org/ontology/core/Core/">
@@ -11,7 +12,8 @@
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.industrialontologies.org/ontology/maintenance/MaintenanceReferenceOntology/"
+<rdf:RDF
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
 	xmlns:dcterms="http://purl.org/dc/terms/"
 	xmlns:iof-av="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/"
 	xmlns:iof-core="https://spec.industrialontologies.org/ontology/core/Core/"
@@ -94,18 +96,23 @@
 		<rdfs:subClassOf rdf:resource="&iof-maint;MaintenanceState"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&obo;BFO_0000167"/>
-				<owl:someValuesFrom rdf:resource="&iof-core;MaintainableMaterialItem"/>
+				<owl:onProperty rdf:resource="&obo;BFO_0000062"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&iof-maint;DegradedState">
+							</rdf:Description>
+							<rdf:Description rdf:about="&iof-maint;OperatingState">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty>
-					<rdf:Description>
-						<owl:inverseOf rdf:resource="&obo;BFO_0000063"/>
-					</rdf:Description>
-				</owl:onProperty>
-				<owl:someValuesFrom rdf:resource="&iof-maint;MaintenanceState"/>
+				<owl:onProperty rdf:resource="&obo;BFO_0000167"/>
+				<owl:someValuesFrom rdf:resource="&iof-core;MaintainableMaterialItem"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -377,6 +384,33 @@
 		</rdfs:subClassOf>
 		<rdfs:label>qualified maintenance person</rdfs:label>
 		<rdfs:seeAlso>qualification specification</rdfs:seeAlso>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:intersectionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&iof-core;Person">
+					</rdf:Description>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&obo;BFO_0000056"/>
+						<owl:someValuesFrom rdf:resource="&iof-maint;MaintenanceActivity"/>
+					</owl:Restriction>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&iof-core;satisfiesRequirement"/>
+						<owl:someValuesFrom>
+							<owl:Class>
+								<owl:intersectionOf rdf:parseType="Collection">
+									<rdf:Description rdf:about="&iof-maint;QualificationSpecification">
+									</rdf:Description>
+									<owl:Restriction>
+										<owl:onProperty rdf:resource="&iof-core;prescribes"/>
+										<owl:someValuesFrom rdf:resource="&iof-maint;MaintenanceActivity"/>
+									</owl:Restriction>
+								</owl:intersectionOf>
+							</owl:Class>
+						</owl:someValuesFrom>
+					</owl:Restriction>
+				</owl:intersectionOf>
+			</owl:Class>
+		</owl:equivalentClass>
 		<skos:example>electrician, fitter, mechanic</skos:example>
 		<iof-av:explanatoryNote>Qualified person on its own is not particularly useful unless reasoning is constrained to only the individuals of interest at some time. Specific subtypes of qualified person are necessary to determine if specific qualification types  are satisfied. Still, care must be taken when reasoning over temporal information as, if the critieria are met at some time, the calssification will hold.</iof-av:explanatoryNote>
 		<iof-av:firstOrderLogicDefinition>QualifiedPerson(x) ↔ Person(x) ∧ ∃y(MaintenanceActivity(y) ∧ partcipatesInAtSomeTime(x,y) ∧ ∃z(QualificationSpecification(z) ∧ prescribedBy(y, z) ∧ satisfiesRequirement(x,z)))</iof-av:firstOrderLogicDefinition>
@@ -439,6 +473,7 @@
 	
 	<owl:ObjectProperty rdf:about="&iof-maint;hasState">
 		<rdfs:subPropertyOf rdf:resource="&obo;BFO_0000056"/>
+		<rdfs:label>hasMaintainableMaterialState</rdfs:label>
 		<rdfs:domain rdf:resource="&iof-core;MaintainableMaterialItem"/>
 		<rdfs:range rdf:resource="&iof-maint;MaintenanceState"/>
 		<owl:inverseOf rdf:resource="&iof-maint;stateOf"/>
@@ -465,6 +500,7 @@
 	
 	<owl:ObjectProperty rdf:about="&iof-maint;stateOf">
 		<rdfs:subPropertyOf rdf:resource="&obo;BFO_0000167"/>
+		<rdfs:label>maintainableMaterialStateOf</rdfs:label>
 		<rdfs:domain rdf:resource="&iof-maint;MaintenanceState"/>
 		<rdfs:range rdf:resource="&iof-core;MaintainableMaterialItem"/>
 		<iof-av:maturity>Provisional</iof-av:maturity>


### PR DESCRIPTION
For qualified person
1. Added line to restriction as suggested by Milos email 22/3 to Melinda
2. Changed class to primitive
3. No change to FOL definition as it is the intended definition
4. Note that the FOL description provided is MORE expressive than the OWL restrictions. If we made it a defined class suggested by Milos we ran the risk that a (qualified) welder doing an electrical task would be assumed to be a qualified electrical person.

For maintenance state
1. There is a label change for object property assoc with maintenance state
