### PR TITLE
Fix some typos

### DIFF
--- a/core/Core.rdf
+++ b/core/Core.rdf
@@ -22,7 +22,7 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.industrialontologies.org/ontology/core/Core/">
-		<rdfs:label xml:lang="en-US">Core Ontology</rdfs:label>
+		<rdfs:label xml:lang="en-US">IOF Core Ontology</rdfs:label>
 		<dcterms:abstract>The IOF Core Ontology contains notions found to be common across multiple manufacturing domains. This file is an RDF implementation of these notions. The ontology utilizes the Basic Formal Ontology or BFO as a top-level ontology but also borrows terms from various domain-independent or mid-level ontologies. The purpose of the ontology is to serve as a foundation for ensuring consistency and interoperability across various domain-specific reference ontologies the IOF publishes.</dcterms:abstract>
 		<dcterms:contributor xml:lang="en-US">Ana Teresa Correia, Institut fuer angewandte Systemtechnik Bremen GmbH (ATB-Bremen)</dcterms:contributor>
 		<dcterms:contributor xml:lang="en-US">Barry Smith, University at Buffalo</dcterms:contributor>
@@ -236,7 +236,7 @@
 		<iof-av:adaptedFrom>APICS 14 ed., 2013, term by the same name; DoD Standard Practice, Identification Marking of US Military Property (MIL-STD-130N Nov. 2012) https://dodprocurementtoolbox.com/cms/sites/default/files/resources/2016-03/MIL-Std130N_Ch1_4.pdf, term by the same name</iof-av:adaptedFrom>
 		<iof-av:counterExample>a portion of material; a piece of glass; a rod of aluminum; a roll of aluminum; an engine block</iof-av:counterExample>
 		<iof-av:explanatoryNote>Although the term is polysemous and used in a number of other domains beyond manufacturing, it is introduced here as a covering term for any man-made artifact that satisfies the conditions provided, and independent of modality. We expect various subclasses of assembly to be introduced in future along with more precise heuristics for the various modalities in which they exist.</iof-av:explanatoryNote>
-		<iof-av:firstOrderLogicAxiom>LA1: Assembly(x) → MaterialArtifact(x) ∧ ∃c,∃c&apos;(MaterialComponent(c) ∧ MaterialComponent(c&apos;) componentPartOfAtAllTimes(c,x) ∧ componentPartOfAtAllTimes(c&apos;,x) ∧ ¬(c=c&apos;∨ (componentPartOfAtAllTimes(c,c&apos;) ∨ componentPartOfAtAllTimes(c&apos;,c))))</iof-av:firstOrderLogicAxiom>
+		<iof-av:firstOrderLogicAxiom>LA1: Assembly(x) → MaterialArtifact(x) ∧ ∃c,∃c&apos;(MaterialComponent(c) ∧ MaterialComponent(c&apos;) ∧ componentPartOfAtAllTimes(c,x) ∧ componentPartOfAtAllTimes(c&apos;,x) ∧ ¬(c=c&apos;∨ (componentPartOfAtAllTimes(c,c&apos;) ∨ componentPartOfAtAllTimes(c&apos;,c))))</iof-av:firstOrderLogicAxiom>
 		<iof-av:firstOrderLogicAxiom>LA2: MaterialArtifact(x) ∧ ∃p(AssemblyProcess(p) ∧ isSpecifiedOutputOf(x,p)) → Assembly(x)</iof-av:firstOrderLogicAxiom>
 		<iof-av:isPrimitive rdf:datatype="&xsd;boolean">true</iof-av:isPrimitive>
 		<iof-av:naturalLanguageDefinition xml:lang="en-US">material artifact that is composed of material components that are physically connected and that is capable of disassembly</iof-av:naturalLanguageDefinition>
@@ -1644,7 +1644,7 @@ Services as products as well as software products will be considered in the next
 ∧ isMeasuredValueOfAtSomeTime(x,e))</iof-av:firstOrderLogicDefinition>
 		<iof-av:maturity rdf:resource="&iof-av;Provisional"/>
 		<iof-av:naturalLanguageDefinition xml:lang="en-US">value expression that contains the measured value of an attribute (specifically dependent continuant or process characteristic or temporal region)</iof-av:naturalLanguageDefinition>
-		<iof-av:semiFormalNaturalLanguageDefinition>every instance of &apos;measured value expression&apos; is defined exactly as an instance of &apos;information content entity&apos; that &apos;is measured value of at some time&apos; some &apos;process characteristic&apos; or &apos;temporal region&apos; or &apos;specifically dependent continuant&apos;</iof-av:semiFormalNaturalLanguageDefinition>
+		<iof-av:semiFormalNaturalLanguageDefinition>every instance of &apos;measured value expression&apos; is defined exactly as an instance of &apos;value expression&apos; that &apos;is measured value of at some time&apos; some &apos;process characteristic&apos; or &apos;temporal region&apos; or &apos;specifically dependent continuant&apos;</iof-av:semiFormalNaturalLanguageDefinition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&iof-core;MeasurementCapability">
@@ -2049,7 +2049,7 @@ http://docs.opengeospatial.org/is/18-010r7/18-010r7.html#106</iof-av:explanatory
 		<iof-av:firstOrderLogicAxiom>ProcessCharacteristic(x) → Occurrent(x)</iof-av:firstOrderLogicAxiom>
 		<iof-av:isPrimitive rdf:datatype="&xsd;boolean">true</iof-av:isPrimitive>
 		<iof-av:naturalLanguageDefinition xml:lang="en-US">attribute of a process</iof-av:naturalLanguageDefinition>
-		<iof-av:primitiveRationale>This term is expected to remain primitive as it is highly unlikely that a a set of conditions will be created such that no circularity is introduced.</iof-av:primitiveRationale>
+		<iof-av:primitiveRationale>This term is expected to remain primitive as it is highly unlikely that a set of conditions will be created such that no circularity is introduced.</iof-av:primitiveRationale>
 		<iof-av:semiFormalNaturalLanguageAxiom>if x is a &apos;process characteristic&apos; then x is an &apos;occurrent&apos;</iof-av:semiFormalNaturalLanguageAxiom>
 	</owl:Class>
 	

--- a/core/meta/AnnotationVocabulary.rdf
+++ b/core/meta/AnnotationVocabulary.rdf
@@ -410,7 +410,7 @@ HOWEVER: While acronyms and other abbreviations may be provided as annotations t
 		<rdfs:label xml:lang="en-US">symbol</rdfs:label>
 		<skos:definition xml:lang="en-US">abbreviation that is a design, mark, or charaters(s) used conventionally to represent something, such as currency, quantity, or variable in an expression</skos:definition>
 		<skos:example xml:lang="en-US">Chemical Symbols: H, O, Mg
-Units of Measure: Km, Kg, G</skos:example>
+Units of Measure: km, kg, g</skos:example>
 		<iof-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/</iof-av:adaptedFrom>
 	</owl:AnnotationProperty>
 	


### PR DESCRIPTION
This fixes some typos.

In case of the [naturalLanguageDefinition](https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/naturalLanguageDefinition) of [MeasuredValueExpression](https://spec.industrialontologies.org/ontology/core/Core/MeasuredValueExpression) I am interested to get a confirmation that it is a typo.

Regarding [symbol](https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/symbol): Km, Kg, G are proper symbols for KelvinMeter, KelvinGram and Gauss. But I guess the intention was to have simple examples like kilometer, kilogram and gram.