### PR TITLE
About file fixes

### DIFF
--- a/AboutIOFDev.rdf
+++ b/AboutIOFDev.rdf
@@ -25,7 +25,7 @@
     <dcterms:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dcterms:license>
     <dcterms:title>Industrial Ontology Foundry (IOF) Ontology - Development</dcterms:title>
     <iof-av:copyright>Copyright (c) 2022, 2023, Open Applications Group</iof-av:copyright>
-    <owl:versionIRI rdf:resource="https://spec.industrialontologies.org/ontology/202301/AboutIOFDev/"/>
+    <owl:versionIRI rdf:resource="https://spec.industrialontologies.org/ontology/202401/AboutIOFDev/"/>
     <iof-av:maturity rdf:resource="&iof-av;Provisional"/>
 
     <!-- load from the cache -->

--- a/AboutIOFDev.rdf
+++ b/AboutIOFDev.rdf
@@ -29,12 +29,12 @@
     <iof-av:maturity rdf:resource="&iof-av;Provisional"/>
 
     <!-- load from the cache -->
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/bfo/2020/bfo.rdf"/>
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/CMNS/AnnotationVocabulary.rdf"/>
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/CMNS/TextDatatype.rdf"/>
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/CMNS/Collections.rdf"/>
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/CMNS/Designators.rdf"/>
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/CMNS/Identifiers.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/bfo/2020/bfo.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/AnnotationVocabulary.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/TextDatatype.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Collections.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Designators.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Identifiers.rdf"/>
     
     <!-- load from normative locations -->
     <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/Core/"/>

--- a/AboutIOFProd.rdf
+++ b/AboutIOFProd.rdf
@@ -33,7 +33,7 @@
     <iof-av:maturity rdf:resource="&iof-av;Released"/>
 
     <!-- load from the cache -->
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/bfo/2020/bfo.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/bfo/2020/bfo.rdf"/>
         
     <!-- load from normative locations -->
     <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/Core/"/>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -6,7 +6,12 @@
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Collections/" uri="./cache/CMNS/Collections.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Designators/" uri="./cache/CMNS/Designators.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Identifiers/" uri="./cache/CMNS/Identifiers.rdf"/>
-  
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/bfo/2020/bfo.rdf" uri="./cache/bfo/2020/bfo.rdf"/>
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Identifiers.rdf" uri="./cache/CMNS/Identifiers.rdf"/>
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Designators.rdf" uri="./cache/CMNS/Designators.rdf"/>
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Collections.rdf" uri="./cache/CMNS/Collections.rdf"/>    
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/TextDatatype.rdf" uri="./cache/CMNS/TextDatatype.rdf"/>    
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/AnnotationVocabulary.rdf" uri="./cache/CMNS/AnnotationVocabulary.rdf"/>      
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/supplychain/SupplyChain/" uri="./supplychain/SupplyChain.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/maintenance/Maintenance/" uri="./maintenance/Maintenance.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/Core/" uri="./core/Core.rdf"/>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -5,13 +5,7 @@
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/TextDatatype/" uri="./cache/CMNS/TextDatatype.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Collections/" uri="./cache/CMNS/Collections.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Designators/" uri="./cache/CMNS/Designators.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Identifiers/" uri="./cache/CMNS/Identifiers.rdf"/>
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/bfo/2020/bfo.rdf" uri="./cache/bfo/2020/bfo.rdf"/>
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Identifiers.rdf" uri="./cache/CMNS/Identifiers.rdf"/>
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Designators.rdf" uri="./cache/CMNS/Designators.rdf"/>
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Collections.rdf" uri="./cache/CMNS/Collections.rdf"/>    
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/TextDatatype.rdf" uri="./cache/CMNS/TextDatatype.rdf"/>    
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/AnnotationVocabulary.rdf" uri="./cache/CMNS/AnnotationVocabulary.rdf"/>      
+    <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Identifiers/" uri="./cache/CMNS/Identifiers.rdf"/> 
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/supplychain/SupplyChain/" uri="./supplychain/SupplyChain.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/maintenance/Maintenance/" uri="./maintenance/Maintenance.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/Core/" uri="./core/Core.rdf"/>

--- a/core/AboutIOFDev.rdf
+++ b/core/AboutIOFDev.rdf
@@ -25,7 +25,7 @@
     <dcterms:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dcterms:license>
     <dcterms:title>Industrial Ontology Foundry (IOF) Ontology - Development</dcterms:title>
     <iof-av:copyright>Copyright (c) 2022, 2023, Open Applications Group</iof-av:copyright>
-    <owl:versionIRI rdf:resource="https://spec.industrialontologies.org/ontology/202301/core/AboutIOFDev/"/>
+    <owl:versionIRI rdf:resource="https://spec.industrialontologies.org/ontology/202401/core/AboutIOFDev/"/>
     <iof-av:maturity rdf:resource="&iof-av;Provisional"/>
 
     <!-- load from the cache -->

--- a/core/AboutIOFDev.rdf
+++ b/core/AboutIOFDev.rdf
@@ -9,7 +9,7 @@
   <!ENTITY iof-av "https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/">
   <!ENTITY dcterms "http://purl.org/dc/terms/"> 
 ]>  
-<rdf:RDF xml:base="https://spec.industrialontologies.org/ontology/AboutIOFDev/"
+<rdf:RDF xml:base="https://spec.industrialontologies.org/ontology/core/AboutIOFDev/"
   xmlns:dct="http://purl.org/dc/terms/"
   xmlns:owl="http://www.w3.org/2002/07/owl#"
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -19,29 +19,31 @@
   xmlns:iof-av="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/"
   xmlns:dcterms="http://purl.org/dc/terms/">
   
-    <owl:Ontology rdf:about="https://spec.industrialontologies.org/ontology/AboutIOFDev/">
+    <owl:Ontology rdf:about="https://spec.industrialontologies.org/ontology/core/AboutIOFDev/">
     <rdfs:label xml:lang="en-US">About IOF Development</rdfs:label>
     <dcterms:abstract>This ontology defines the scope of development maturity level IOF ontologies.</dcterms:abstract>
     <dcterms:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dcterms:license>
     <dcterms:title>Industrial Ontology Foundry (IOF) Ontology - Development</dcterms:title>
     <iof-av:copyright>Copyright (c) 2022, 2023, Open Applications Group</iof-av:copyright>
-    <owl:versionIRI rdf:resource="https://spec.industrialontologies.org/ontology/202301/AboutIOFDev/"/>
+    <owl:versionIRI rdf:resource="https://spec.industrialontologies.org/ontology/202301/core/AboutIOFDev/"/>
     <iof-av:maturity rdf:resource="&iof-av;Provisional"/>
 
     <!-- load from the cache -->
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/bfo/2020/bfo.rdf"/>
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/CMNS/AnnotationVocabulary.rdf"/>
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/CMNS/TextDatatype.rdf"/>
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/CMNS/Collections.rdf"/>
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/CMNS/Designators.rdf"/>
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/CMNS/Identifiers.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/bfo/2020/bfo.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/AnnotationVocabulary.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/TextDatatype.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Collections.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Designators.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Identifiers.rdf"/>
     
     <!-- load from normative locations -->
     <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/Core/"/>
     <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/"/>
     <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/meta/MappingAnnotationVocabularyToCommons/"/>
     <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/MappingCommonsToIOF/"/>
+    <!-- should these be here for core?
     <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/maintenance/Maintenance/"/>
     <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/supplychain/SupplyChain/"/>
+    -->
   </owl:Ontology>
 </rdf:RDF>

--- a/core/AboutIOFDev.rdf
+++ b/core/AboutIOFDev.rdf
@@ -41,9 +41,6 @@
     <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/"/>
     <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/meta/MappingAnnotationVocabularyToCommons/"/>
     <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/MappingCommonsToIOF/"/>
-    <!-- should these be here for core?
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/maintenance/Maintenance/"/>
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/supplychain/SupplyChain/"/>
     -->
   </owl:Ontology>
 </rdf:RDF>

--- a/core/AboutIOFProd.rdf
+++ b/core/AboutIOFProd.rdf
@@ -25,7 +25,7 @@
     <dcterms:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dcterms:license>
     <dcterms:title>Industrial Ontology Foundry (IOF) Ontology - Production</dcterms:title>
     <iof-av:copyright>Copyright (c) 2022, 2023, Open Applications Group</iof-av:copyright>
-    <owl:versionIRI rdf:resource="https://spec.industrialontologies.org/ontology/202301/core/AboutIOFProd/"/>
+    <owl:versionIRI rdf:resource="https://spec.industrialontologies.org/ontology/202401/core/AboutIOFProd/"/>
     <iof-av:maturity rdf:resource="&iof-av;Released"/>
 
     <!-- load from the cache -->

--- a/core/AboutIOFProd.rdf
+++ b/core/AboutIOFProd.rdf
@@ -9,7 +9,7 @@
   <!ENTITY iof-av "https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/">
   <!ENTITY dcterms "http://purl.org/dc/terms/"> 
 ]>  
-<rdf:RDF xml:base="https://spec.industrialontologies.org/ontology/AboutIOFProd/"
+<rdf:RDF xml:base="https://spec.industrialontologies.org/ontology/core/AboutIOFProd/"
   xmlns:dct="http://purl.org/dc/terms/"
   xmlns:owl="http://www.w3.org/2002/07/owl#"
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -19,21 +19,17 @@
   xmlns:iof-av="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/"
   xmlns:dcterms="http://purl.org/dc/terms/">
   
-  <owl:Ontology rdf:about="https://spec.industrialontologies.org/ontology/AboutIOFProd/">
-  </owl:Ontology>
-
-
-    <owl:Ontology rdf:about="https://spec.industrialontologies.org/ontology/AboutIOFProd/">
+  <owl:Ontology rdf:about="https://spec.industrialontologies.org/ontology/core/AboutIOFProd/">
     <rdfs:label xml:lang="en-US">About IOF Production</rdfs:label>
     <dcterms:abstract>This ontology defines the scope of production maturity level IOF ontologies.</dcterms:abstract>
     <dcterms:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dcterms:license>
     <dcterms:title>Industrial Ontology Foundry (IOF) Ontology - Production</dcterms:title>
     <iof-av:copyright>Copyright (c) 2022, 2023, Open Applications Group</iof-av:copyright>
-    <owl:versionIRI rdf:resource="https://spec.industrialontologies.org/ontology/202301/AboutIOFProd/"/>
+    <owl:versionIRI rdf:resource="https://spec.industrialontologies.org/ontology/202301/core/AboutIOFProd/"/>
     <iof-av:maturity rdf:resource="&iof-av;Released"/>
 
     <!-- load from the cache -->
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/bfo/2020/bfo.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/bfo/2020/bfo.rdf"/>
         
     <!-- load from normative locations -->
     <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/Core/"/>

--- a/core/catalog-v001.xml
+++ b/core/catalog-v001.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <uri id="Imports Wizard Entry" name="http://purl.obolibrary.org/obo/bfo/2020/bfo.owl" uri="../cache/bfo/2020/bfo.rdf"/>
-  
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/bfo/2020/bfo.rdf" uri="../cache/bfo/2020/bfo.rdf"/>
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Identifiers.rdf" uri="../cache/CMNS/Identifiers.rdf"/>
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Designators.rdf" uri="../cache/CMNS/Designators.rdf"/>
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Collections.rdf" uri="../cache/CMNS/Collections.rdf"/>    
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/TextDatatype.rdf" uri="../cache/CMNS/TextDatatype.rdf"/>    
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/AnnotationVocabulary.rdf" uri="../cache/CMNS/AnnotationVocabulary.rdf"/>    
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/" uri="./meta/AnnotationVocabulary.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/MappingCommonsToIOF/" uri="./commonstocoremapping/MappingCommonsToIOF.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/meta/MappingAnnotationVocabularyToCommons/" uri="./commonstocoremapping/meta/MappingAnnotationVocabularyToCommons.rdf"/>

--- a/core/catalog-v001.xml
+++ b/core/catalog-v001.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <uri id="Imports Wizard Entry" name="http://purl.obolibrary.org/obo/bfo/2020/bfo.owl" uri="../cache/bfo/2020/bfo.rdf"/>
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/bfo/2020/bfo.rdf" uri="../cache/bfo/2020/bfo.rdf"/>
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Identifiers.rdf" uri="../cache/CMNS/Identifiers.rdf"/>
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Designators.rdf" uri="../cache/CMNS/Designators.rdf"/>
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Collections.rdf" uri="../cache/CMNS/Collections.rdf"/>    
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/TextDatatype.rdf" uri="../cache/CMNS/TextDatatype.rdf"/>    
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/AnnotationVocabulary.rdf" uri="../cache/CMNS/AnnotationVocabulary.rdf"/>    
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/" uri="./meta/AnnotationVocabulary.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/MappingCommonsToIOF/" uri="./commonstocoremapping/MappingCommonsToIOF.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/meta/MappingAnnotationVocabularyToCommons/" uri="./commonstocoremapping/meta/MappingAnnotationVocabularyToCommons.rdf"/>

--- a/maintenance/AboutIOFDev.rdf
+++ b/maintenance/AboutIOFDev.rdf
@@ -9,7 +9,7 @@
   <!ENTITY iof-av "https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/">
   <!ENTITY dcterms "http://purl.org/dc/terms/"> 
 ]>  
-<rdf:RDF xml:base="https://spec.industrialontologies.org/ontology/AboutIOFDev/"
+<rdf:RDF xml:base="https://spec.industrialontologies.org/ontology/maintenance/AboutIOFDev/"
   xmlns:dct="http://purl.org/dc/terms/"
   xmlns:owl="http://www.w3.org/2002/07/owl#"
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -19,13 +19,13 @@
   xmlns:iof-av="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/"
   xmlns:dcterms="http://purl.org/dc/terms/">
   
-    <owl:Ontology rdf:about="https://spec.industrialontologies.org/ontology/AboutIOFDev/">
+    <owl:Ontology rdf:about="https://spec.industrialontologies.org/ontology/maintenance/AboutIOFDev/">
     <rdfs:label xml:lang="en-US">About IOF Development</rdfs:label>
     <dcterms:abstract>This ontology defines the scope of development maturity level IOF ontologies.</dcterms:abstract>
     <dcterms:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dcterms:license>
     <dcterms:title>Industrial Ontology Foundry (IOF) Ontology - Development</dcterms:title>
     <iof-av:copyright>Copyright (c) 2022, 2023, Open Applications Group</iof-av:copyright>
-    <owl:versionIRI rdf:resource="https://spec.industrialontologies.org/ontology/202301/AboutIOFDev/"/>
+    <owl:versionIRI rdf:resource="https://spec.industrialontologies.org/ontology/202401/maintenance/AboutIOFDev/"/>
     <iof-av:maturity rdf:resource="&iof-av;Provisional"/>
 
     <!-- load from the cache -->

--- a/maintenance/AboutIOFDev.rdf
+++ b/maintenance/AboutIOFDev.rdf
@@ -29,7 +29,7 @@
     <iof-av:maturity rdf:resource="&iof-av;Provisional"/>
 
     <!-- load from the cache -->
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/bfo/2020/bfo.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/bfo/2020/bfo.rdf"/>
     
     <!-- load from normative locations -->
     <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/Core/"/>

--- a/maintenance/AboutIOFDev.rdf
+++ b/maintenance/AboutIOFDev.rdf
@@ -34,7 +34,6 @@
     <!-- load from normative locations -->
     <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/Core/"/>
     <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/"/>
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/meta/MappingAnnotationVocabularyToCommons/"/>
     <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/maintenance/Maintenance/"/>
   </owl:Ontology>
 </rdf:RDF>

--- a/maintenance/catalog-v001.xml
+++ b/maintenance/catalog-v001.xml
@@ -2,6 +2,7 @@
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/maintenance/Maintenance/" uri="Maintenance.rdf"/>
     <uri id="Imports Wizard Entry" name="http://purl.obolibrary.org/obo/bfo/2020/bfo.owl" uri="../cache/bfo/2020/bfo.rdf"/>
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/bfo/2020/bfo.rdf" uri="../cache/bfo/2020/bfo.rdf"/>    
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/" uri="../core/meta/AnnotationVocabulary.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/Core/" uri="../core/Core.rdf"/>
 </catalog>

--- a/maintenance/catalog-v001.xml
+++ b/maintenance/catalog-v001.xml
@@ -2,7 +2,6 @@
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/maintenance/Maintenance/" uri="Maintenance.rdf"/>
     <uri id="Imports Wizard Entry" name="http://purl.obolibrary.org/obo/bfo/2020/bfo.owl" uri="../cache/bfo/2020/bfo.rdf"/>
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/bfo/2020/bfo.rdf" uri="../cache/bfo/2020/bfo.rdf"/>    
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/" uri="../core/meta/AnnotationVocabulary.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/Core/" uri="../core/Core.rdf"/>
 </catalog>

--- a/maintenance/catalog-v001.xml
+++ b/maintenance/catalog-v001.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/maintenance/Maintenance/" uri="Maintenance.rdf"/>
     <uri id="Imports Wizard Entry" name="http://purl.obolibrary.org/obo/bfo/2020/bfo.owl" uri="../cache/bfo/2020/bfo.rdf"/>
-  
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/" uri="../core/meta/AnnotationVocabulary.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/Core/" uri="../core/Core.rdf"/>
 </catalog>

--- a/supplychain/AboutIOFDev.rdf
+++ b/supplychain/AboutIOFDev.rdf
@@ -9,7 +9,7 @@
   <!ENTITY iof-av "https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/">
   <!ENTITY dcterms "http://purl.org/dc/terms/"> 
 ]>  
-<rdf:RDF xml:base="https://spec.industrialontologies.org/ontology/AboutIOFDev/"
+<rdf:RDF xml:base="https://spec.industrialontologies.org/ontology/supplychain/AboutIOFDev/"
   xmlns:dct="http://purl.org/dc/terms/"
   xmlns:owl="http://www.w3.org/2002/07/owl#"
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -19,13 +19,13 @@
   xmlns:iof-av="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/"
   xmlns:dcterms="http://purl.org/dc/terms/">
   
-    <owl:Ontology rdf:about="https://spec.industrialontologies.org/ontology/AboutIOFDev/">
+    <owl:Ontology rdf:about="https://spec.industrialontologies.org/ontology/supplychain/AboutIOFDev/">
     <rdfs:label xml:lang="en-US">About IOF Development</rdfs:label>
     <dcterms:abstract>This ontology defines the scope of development maturity level IOF ontologies.</dcterms:abstract>
     <dcterms:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dcterms:license>
     <dcterms:title>Industrial Ontology Foundry (IOF) Ontology - Development</dcterms:title>
     <iof-av:copyright>Copyright (c) 2022, 2023, Open Applications Group</iof-av:copyright>
-    <owl:versionIRI rdf:resource="https://spec.industrialontologies.org/ontology/202301/AboutIOFDev/"/>
+    <owl:versionIRI rdf:resource="https://spec.industrialontologies.org/ontology/202401/supplychain/AboutIOFDev/"/>
     <iof-av:maturity rdf:resource="&iof-av;Provisional"/>
 
     <!-- load from the cache -->

--- a/supplychain/AboutIOFDev.rdf
+++ b/supplychain/AboutIOFDev.rdf
@@ -29,12 +29,12 @@
     <iof-av:maturity rdf:resource="&iof-av;Provisional"/>
 
     <!-- load from the cache -->
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/bfo/2020/bfo.rdf"/>
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/CMNS/AnnotationVocabulary.rdf"/>
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/CMNS/TextDatatype.rdf"/>
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/CMNS/Collections.rdf"/>
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/CMNS/Designators.rdf"/>
-    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/cache/CMNS/Identifiers.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/bfo/2020/bfo.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/AnnotationVocabulary.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/TextDatatype.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Collections.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Designators.rdf"/>
+    <owl:imports rdf:resource="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Identifiers.rdf"/>
     
     <!-- load from normative locations -->
     <owl:imports rdf:resource="https://spec.industrialontologies.org/ontology/core/Core/"/>

--- a/supplychain/catalog-v001.xml
+++ b/supplychain/catalog-v001.xml
@@ -7,6 +7,12 @@
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Collections/" uri="../cache/CMNS/Collections.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Designators/" uri="../cache/CMNS/Designators.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Identifiers/" uri="../cache/CMNS/Identifiers.rdf"/>
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/bfo/2020/bfo.rdf" uri="../cache/bfo/2020/bfo.rdf"/>
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Identifiers.rdf" uri="../cache/CMNS/Identifiers.rdf"/>
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Designators.rdf" uri="../cache/CMNS/Designators.rdf"/>
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Collections.rdf" uri="../cache/CMNS/Collections.rdf"/>    
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/TextDatatype.rdf" uri="../cache/CMNS/TextDatatype.rdf"/>    
+    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/AnnotationVocabulary.rdf" uri="../cache/CMNS/AnnotationVocabulary.rdf"/>      
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/meta/MappingAnnotationVocabularyToCommons/" uri="../core/commonstocoremapping/meta/MappingAnnotationVocabularyToCommons.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/" uri="../core/meta/AnnotationVocabulary.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/MappingCommonsToIOF/" uri="../core/commonstocoremapping/MappingCommonsToIOF.rdf"/>

--- a/supplychain/catalog-v001.xml
+++ b/supplychain/catalog-v001.xml
@@ -6,13 +6,7 @@
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/TextDatatype/" uri="../cache/CMNS/TextDatatype.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Collections/" uri="../cache/CMNS/Collections.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Designators/" uri="../cache/CMNS/Designators.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Identifiers/" uri="../cache/CMNS/Identifiers.rdf"/>
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/bfo/2020/bfo.rdf" uri="../cache/bfo/2020/bfo.rdf"/>
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Identifiers.rdf" uri="../cache/CMNS/Identifiers.rdf"/>
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Designators.rdf" uri="../cache/CMNS/Designators.rdf"/>
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/Collections.rdf" uri="../cache/CMNS/Collections.rdf"/>    
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/TextDatatype.rdf" uri="../cache/CMNS/TextDatatype.rdf"/>    
-    <uri id="Imports Wizard Entry" name="https://spec.industrialontologies.org/iof/ontology/master/latest/cache/CMNS/AnnotationVocabulary.rdf" uri="../cache/CMNS/AnnotationVocabulary.rdf"/>      
+    <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Identifiers/" uri="../cache/CMNS/Identifiers.rdf"/>    
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/meta/MappingAnnotationVocabularyToCommons/" uri="../core/commonstocoremapping/meta/MappingAnnotationVocabularyToCommons.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/" uri="../core/meta/AnnotationVocabulary.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/MappingCommonsToIOF/" uri="../core/commonstocoremapping/MappingCommonsToIOF.rdf"/>

--- a/supplychain/catalog-v001.xml
+++ b/supplychain/catalog-v001.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/supplychain/SupplyChain/" uri="SupplyChain.rdf"/>
     <uri id="Imports Wizard Entry" name="http://purl.obolibrary.org/obo/bfo/2020/bfo.owl" uri="../cache/bfo/2020/bfo.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/AnnotationVocabulary/" uri="../cache/CMNS/AnnotationVocabulary.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/TextDatatype/" uri="../cache/CMNS/TextDatatype.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Collections/" uri="../cache/CMNS/Collections.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Designators/" uri="../cache/CMNS/Designators.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Identifiers/" uri="../cache/CMNS/Identifiers.rdf"/>
-  
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/meta/MappingAnnotationVocabularyToCommons/" uri="../core/commonstocoremapping/meta/MappingAnnotationVocabularyToCommons.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/" uri="../core/meta/AnnotationVocabulary.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.industrialontologies.org/ontology/core/commonstocoremapping/MappingCommonsToIOF/" uri="../core/commonstocoremapping/MappingCommonsToIOF.rdf"/>


### PR DESCRIPTION
Made changes necessary to make the "about" files load properly. In particular, the new "about" files had incorrect IRIs, and all the "about" files referencing cache IRIs needed "master/latest/" inserted into them.

**Important Note**
I just had an important insight into one of Pawel’s comments that may throw a monkey wrench into what we've been trying to accomplish. If the “about” files really exist only for the build process, then they should be referencing only local files. If we were to wipe out everything, including the web server for our IRIs, and start a build from scratch, the build server wouldn’t find the files it needs in order to build that web server!