### PR TITLE
fix iof-av:adaptedFrom of iof-core:hasSpecifiedOutput

### DIFF
--- a/core/Core.rdf
+++ b/core/Core.rdf
@@ -3383,7 +3383,7 @@ category within a classification scheme of an entity that the value expression i
 		<rdfs:range rdf:resource="&bfo;BFO_0000002"/>
 		<owl:inverseOf rdf:resource="&iof-core;isSpecifiedOutputOf"/>
 		<skos:example xml:lang="en-US">biopharmaceutical production process has specified output an antibody solution of 99.999% purity; a simulation execution has specified output a prediction of part porosity; a temperature measurement process has specified output a temperature measurement result; a car manufacturing process has specified output a car</skos:example>
-		<iof-av:adaptedFrom>http://purl.obolibrary.org/obo/IAO_0000122</iof-av:adaptedFrom>
+		<iof-av:adaptedFrom>http://purl.obolibrary.org/obo/OBI_0000299</iof-av:adaptedFrom>
 		<iof-av:explanatoryNote>this relation was added to specifically model the outputs that are not byproducts/wasteproducts</iof-av:explanatoryNote>
 		<iof-av:firstOrderLogicAxiom>hasSpecifiedOutput(x,y) → PlannedProcess(x) ∧ Continuant(y) ∧ ∃o(ObjectiveSpecification(o) ∧ prescribes(o,y) ∧ achievesAtSomeTime(x,o) ∧ hasOutput(x,y))</iof-av:firstOrderLogicAxiom>
 		<iof-av:naturalLanguageDefinition xml:lang="en-US">relation from a planned process to someone or something physical or digital (continuant) that is produced or modified in the planned process as prescribed by an objective</iof-av:naturalLanguageDefinition>


### PR DESCRIPTION
This fixes the value of `iof-av:adaptedFrom` of `iof-core:hasSpecifiedOutput`. The current value is `obo:IAO_0000122` (instance "ready for release"). I guess it should have been `obo:OBI_0000299` (property "has_specified_output")