### PR TITLE
Update catalog-v001.xml for BFO

### DIFF
--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/bfo.owl" uri="./cache/bfo/2020/bfo.rdf"/>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/bfo/2020/bfo.owl" uri="./cache/bfo/2020/bfo.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/AnnotationVocabulary/" uri="./cache/CMNS/AnnotationVocabulary.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/TextDatatype/" uri="./cache/CMNS/TextDatatype.rdf"/>
     <uri id="User Entered Import Resolution" name="https://www.omg.org/spec/Commons/Collections/" uri="./cache/CMNS/Collections.rdf"/>


### PR DESCRIPTION
Updated the BFO IRI to its correct format: http://purl.obolibrary.org/obo/bfo/2020/bfo.owl